### PR TITLE
Update Transaction_Logs_IQ_862600.java

### DIFF
--- a/amazon/Transaction_Logs_IQ_862600.java
+++ b/amazon/Transaction_Logs_IQ_862600.java
@@ -7,7 +7,7 @@ public class Transaction_Logs_IQ_862600 {
         
         for (String line : transactions){
             String[] split = line.split(" ");
-            if (split[0] == split[1]){
+            if (split[0].trim().equals(split[1].trim())){
                 count.put(split[0], count.getOrDefault(split[0], 0) + 1);
             } else {
                 count.put(split[0], count.getOrDefault(split[0], 0) + 1);


### PR DESCRIPTION
#Bugfix  In the code the comparison made between split[0] and split[1] was failing. So I have used the equals() method to solve the problem and the code was accepted 